### PR TITLE
Update based on today's walkthrough

### DIFF
--- a/ethereum-consortium/docs/setupWalkthrough.md
+++ b/ethereum-consortium/docs/setupWalkthrough.md
@@ -87,11 +87,11 @@
       resource and copy the IP.  
 
       Navigate to http://{copied ip}:3001/enodes. Save the returned value
-      {bootnodes}.
+      into a file in the same directory as geth.exe and name it static-nodes.json.
     * Start geth  
     For this step you'll need the {network id} used in Step 3
 
-            geth --datadir c:\geth\data --networkid {nework id} --bootnodes {bootnodes}
+            geth --datadir c:\geth\data --networkid {nework id}
 
     * Done   
     At this point geth should be running and will eventually sychronize blocks


### PR DESCRIPTION
Removed the bootnodes parameter from 94 and added verbiage to save static nodes into static-nodes.json on 90 per your demo today.