### PR TITLE
Tiny tooltip fix for the OMS json example

### DIFF
--- a/ethereum-consortium/template.consortium.json
+++ b/ethereum-consortium/template.consortium.json
@@ -99,7 +99,7 @@
       "type" : "secureObject",
       "defaultValue": {},
       "metadata" : {
-        "description" : "If this value is defined then an OMS agent will be deployed to the machine. { KEY : \"\", WSID :\"\" }"
+        "description" : "If this value is defined then an OMS agent will be deployed to the machine. { \"KEY\" : \"\", \"WSID\" :\"\" }"
       }
     },
     "contentVersion": {


### PR DESCRIPTION
The tooltip currently shows { KEY: "", WSID:""}
instead of { "KEY": "", "WSID":""}