### PR TITLE
updating genesis file to include the chainId

### DIFF
--- a/ethereum-consortium/template.clickOnce.PoA.json
+++ b/ethereum-consortium/template.clickOnce.PoA.json
@@ -89,6 +89,7 @@
     "sealer": "[parameters('genesisPrivateAccount').address]",
     "genesisJson": {
       "config": {
+        "chainId": "[parameters('ethereumNetworkId')]",
         "homesteadBlock": 0,
         "eip150Block": 0,
         "eip155Block": 0,

--- a/ethereum-consortium/template.clickOnce.json
+++ b/ethereum-consortium/template.clickOnce.json
@@ -83,6 +83,7 @@
     "dockerImage": "ethereumex/geth-node:alpine-latest",
     "genesisJson": {
       "config": {
+        "chainId": "[parameters('ethereumNetworkId')]",
         "homesteadBlock": 0,
         "eip155Block": 0,
         "eip158Block": 0,


### PR DESCRIPTION
Metamask will connect to a deployment in Azure with public RPC endpoings, and is able to do reads. But trying to submit transactions through Metamask fails.
Has to do with anti-replay mechanisms, and you need to set a ChainId in the genesis file
https://github.com/MetaMask/metamask-extension/issues/1444
 
I edited the genesis template, set ChainId to be the same as NetworkId, deployed and initial testing works. I'll want to do a bit more testing to make sure it is stable before pull request is approved.   Just submitting PR early so you can review
